### PR TITLE
Add environment vars in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![image](https://github.com/user-attachments/assets/ad617e05-5d45-4b2c-a6b9-5cd095719fa3)
 
-
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/msamgan/laravel-env-keys-checker.svg?style=flat-square)](https://packagist.org/packages/msamgan/laravel-env-keys-checker)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/msamgan/laravel-env-keys-checker/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/msamgan/laravel-env-keys-checker/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/msamgan/laravel-env-keys-checker.svg?style=flat-square)](https://packagist.org/packages/msamgan/laravel-env-keys-checker)
@@ -27,7 +26,11 @@ You can install the package via composer:
 composer require msamgan/laravel-env-keys-checker --dev
 ```
 
-To configure that package, you can add environment variables to your `.env` files. See the [config file](config/env-keys-checker.php) for details.
+To configure this package, you can add environment variables to your `.env` files. See
+the [config file](config/env-keys-checker.php) for details. Please make sure that you refresh the config cache after
+adding/updating the environment variables. ``php artisan config:cache``
+
+```bash
 
 If you prefer, you can also publish the config file with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ You can install the package via composer:
 composer require msamgan/laravel-env-keys-checker --dev
 ```
 
-You can publish the config file with (recommended):
+To configure that package, you can add environment variables to your `.env` files. See the [config file](config/env-keys-checker.php) for details.
 
+If you prefer, you can also publish the config file with:
 ```bash
 php artisan vendor:publish --tag="env-keys-checker-config"
 ```

--- a/config/env-keys-checker.php
+++ b/config/env-keys-checker.php
@@ -2,14 +2,14 @@
 
 return [
     // List of all the .env files to ignore while checking the env keys
-    'ignore_files' => [],
+    'ignore_files' => env('KEYS_CHECKER_IGNORE_FILES', []),
 
     // List of all the env keys to ignore while checking the env keys
-    'ignore_keys' => [],
+    'ignore_keys' => env('KEYS_CHECKER_IGNORE_KEYS', []),
 
     // strategy to add the missing keys to the .env file
     // ask: will ask the user to add the missing keys
     // auto: will add the missing keys automatically
     // none: will not add the missing keys
-    'auto_add' => 'ask',
+    'auto_add' => env('KEYS_CHECKER_AUTO_ADD', 'ask'),
 ];

--- a/config/env-keys-checker.php
+++ b/config/env-keys-checker.php
@@ -2,10 +2,10 @@
 
 return [
     // List of all the .env files to ignore while checking the env keys
-    'ignore_files' => env('KEYS_CHECKER_IGNORE_FILES', []),
+    'ignore_files' => explode(',', env('KEYS_CHECKER_IGNORE_FILES', '')),
 
     // List of all the env keys to ignore while checking the env keys
-    'ignore_keys' => env('KEYS_CHECKER_IGNORE_KEYS', []),
+    'ignore_keys' => explode(',', env('KEYS_CHECKER_IGNORE_KEYS', '')),
 
     // strategy to add the missing keys to the .env file
     // ask: will ask the user to add the missing keys


### PR DESCRIPTION
As the defaults are the same this should be fully backwards compatible. The only potential issue is if you have already defined the same environment vars, but that is very unlikely. 