### PR TITLE
Update requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+To use this package:
+
+Temporarily add this fork to the repositories property of your composer.json:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jefhar/laravel-env-keys-checker.git"
+        }
+    ]
+}
+```
+Then update your dependency constraint to reference this branch:
+
+```json
+{
+    "require": {
+        "msamgan/laravel-env-keys-checker": "dev-l12-compatibility",
+    }
+}
+```
+
+Finally, run: `composer update`
+
 # Check if all the keys are available across all the .env files.
 
 ![image](https://github.com/user-attachments/assets/8f80ef4a-a777-46ed-bc49-e70e3c1bec60)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0|^12.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
Update for L12.

The upstream [Laravel Contracts](https://github.com/illuminate/contracts/tree/master) requires PHP 8.3 as minimum version.

## To use this package:

Temporarily add this fork to the repositories property of your composer.json:

```json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/jefhar/laravel-env-keys-checker.git"
        }
    ]
}
```
Then update your dependency constraint to reference this branch:

```json
{
    "require": {
        "msamgan/laravel-env-keys-checker": "dev-l12-compatibility",
    }
}
```

Finally, run: `composer update`